### PR TITLE
Do not use error message text to recognise YDB scheme errors

### DIFF
--- a/internal/resources/changefeed/read.go
+++ b/internal/resources/changefeed/read.go
@@ -2,10 +2,10 @@ package changefeed
 
 import (
 	"context"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ydb-platform/ydb-go-sdk/v3"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/options"
 
@@ -49,7 +49,7 @@ func (h *handler) Read(ctx context.Context, d *schema.ResourceData, meta interfa
 		return err
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), "SCHEME_ERROR") {
+		if ydb.IsOperationErrorSchemeError(err) {
 			// NOTE(shmel1k@): marking as non-existing resource
 			d.SetId("")
 			return nil

--- a/internal/resources/table/index/read.go
+++ b/internal/resources/table/index/read.go
@@ -2,10 +2,10 @@ package index
 
 import (
 	"context"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ydb-platform/ydb-go-sdk/v3"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/options"
 
@@ -39,7 +39,7 @@ func (h *handler) Read(ctx context.Context, d *schema.ResourceData, meta interfa
 		return err
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), "SCHEME_ERROR") {
+		if ydb.IsOperationErrorSchemeError(err) {
 			d.SetId("")
 			return nil
 		}

--- a/internal/resources/table/read.go
+++ b/internal/resources/table/read.go
@@ -2,10 +2,10 @@ package table
 
 import (
 	"context"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/ydb-platform/ydb-go-sdk/v3"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/options"
 
@@ -55,7 +55,7 @@ func (h *handler) Read(ctx context.Context, d *schema.ResourceData, cfg interfac
 		return err
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), "SCHEME_ERROR") {
+		if ydb.IsOperationErrorSchemeError(err) {
 			// NOTE(shmel1k@): marking as non-existing resource
 			d.SetId("")
 			return nil


### PR DESCRIPTION
Since SDK v3 have a lot of helpers to work with YDB errors, I believe that the error text message should not be used to recognise a particular error type.