### PR TITLE
Add support for column-oriented tables

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Terraform Provider",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            // this assumes your workspace is the root of the repo
+            "program": "${workspaceFolder}",
+            "env": {
+                "GODEBUG": "http2debug=1",
+                "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
+                "GRPC_GO_LOG_SEVERITY_LEVEL": "info"
+            },
+            "args": [
+                "-debug",
+            ]
+        }
+    ]
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
 	github.com/stretchr/testify v1.10.0
-	github.com/ydb-platform/ydb-go-sdk/v3 v3.111.3
+	github.com/ydb-platform/ydb-go-sdk/v3 v3.115.7
 )
 
 require google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53 // indirect

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,10 @@ github.com/ydb-platform/ydb-go-genproto v0.0.0-20241112172322-ea1f63298f77 h1:LY
 github.com/ydb-platform/ydb-go-genproto v0.0.0-20241112172322-ea1f63298f77/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.111.3 h1:HECHgZavZbpuTF2X/gWLAZ/uNKa9corWKPKtZeE9uFM=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.111.3/go.mod h1:Pp1w2xxUoLQ3NCNAwV7pvDq0TVQOdtAqs+ZiC+i8r14=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.115.6 h1:TBOFempaj+BQxyXnTCt/lWpoRWtQJ/9wHCRt2/OphrE=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.115.6/go.mod h1:Pp1w2xxUoLQ3NCNAwV7pvDq0TVQOdtAqs+ZiC+i8r14=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.115.7 h1:ZnjIktxylxgVrDIIygMIPqEH3wsmr/l9zx3I376sT0U=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.115.7/go.mod h1:Pp1w2xxUoLQ3NCNAwV7pvDq0TVQOdtAqs+ZiC+i8r14=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/main.go
+++ b/main.go
@@ -1,14 +1,22 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
 	"github.com/ydb-platform/terraform-provider-ydb/ydb"
 )
 
 func main() {
+	var debug bool
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	opts := &plugin.ServeOpts{
+		ProviderAddr: "terraform.storage.ydb.tech/provider/ydb",
 		ProviderFunc: ydb.Provider,
+		Debug:        debug,
 	}
 
 	plugin.Serve(opts)


### PR DESCRIPTION
Support for column-oriented tables

```terraform
resource "ydb_table" "table" {
  path        = "1/2/3/tftest"
  connection_string = var.db-connect
  column {
    name = "a"
    type = "Utf8"
  }

  column {
    name = "b"
    type = "String"
  }

  primary_key = ["a", "b"]
  
  store = "column"

  partitioning_settings {
    partition_by = ["b", "a"]
  }
}
```

generates the code:

```sql
CREATE TABLE table_name (
  a Utf8 NOT NULL,
  b String NOT NULL,
  PRIMARY KEY (a, b)
)
PARTITION BY HASH(b,a)
WITH (
  STORE = COLUMN
);
```