### PR TITLE
feat(changefeed): add initial_scan to ydb_table_changefeed

### DIFF
--- a/internal/resources/changefeed/changefeed.go
+++ b/internal/resources/changefeed/changefeed.go
@@ -37,6 +37,7 @@ type changeDataCaptureSettings struct {
 	Format            *string
 	RetentionPeriod   *string
 	VirtualTimestamps *bool
+	InitialScan       bool
 	Entity            *helpers.YDBEntity
 	TableEntity       *helpers.YDBEntity
 	Consumers         []topictypes.Consumer
@@ -128,6 +129,7 @@ func changefeedResourceSchemaToChangefeedResource(d *schema.ResourceData) (*chan
 	if retentionPeriod, ok := d.Get("retention_period").(string); ok && retentionPeriod != "" {
 		settings.RetentionPeriod = &retentionPeriod
 	}
+	settings.InitialScan = d.Get("initial_scan").(bool)
 	settings.Consumers = expandConsumers(d)
 
 	return settings, nil
@@ -164,6 +166,10 @@ func flattenCDCDescription(
 		return
 	}
 	err = d.Set("virtual_timestamps", cdcDescription.VirtualTimestamp)
+	if err != nil {
+		return
+	}
+	err = d.Set("initial_scan", changefeedResource.InitialScan)
 	if err != nil {
 		return
 	}

--- a/internal/resources/changefeed/yql.go
+++ b/internal/resources/changefeed/yql.go
@@ -36,6 +36,10 @@ func PrepareCreateRequest(cdc *changeDataCaptureSettings) string {
 		buf = helpers.AppendWithEscape(buf, *cdc.RetentionPeriod)
 		buf = append(buf, '"', ')')
 	}
+	if cdc.InitialScan {
+		buf = append(buf, ',', '\n')
+		buf = append(buf, "INITIAL_SCAN = TRUE"...)
+	}
 	buf = append(buf, '\n', ')')
 	return string(buf)
 }

--- a/internal/resources/changefeed/yql_test.go
+++ b/internal/resources/changefeed/yql_test.go
@@ -1,0 +1,31 @@
+package changefeed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareCreateRequest_initialScan(t *testing.T) {
+	format := "JSON"
+	t.Run("omits when false", func(t *testing.T) {
+		q := PrepareCreateRequest(&changeDataCaptureSettings{
+			TablePath:   "my/table",
+			Name:        "cf1",
+			Mode:        "UPDATES",
+			Format:      &format,
+			InitialScan: false,
+		})
+		require.NotContains(t, q, "INITIAL_SCAN")
+	})
+	t.Run("includes when true", func(t *testing.T) {
+		q := PrepareCreateRequest(&changeDataCaptureSettings{
+			TablePath:   "my/table",
+			Name:        "cf1",
+			Mode:        "UPDATES",
+			Format:      &format,
+			InitialScan: true,
+		})
+		require.Contains(t, q, "INITIAL_SCAN = TRUE")
+	})
+}

--- a/sdk/terraform/table/changefeed/resource.go
+++ b/sdk/terraform/table/changefeed/resource.go
@@ -164,6 +164,14 @@ func ResourceSchema() map[string]*schema.Schema {
 			Optional:    true,
 			ForceNew:    true,
 		},
+		"initial_scan": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+			ForceNew: true,
+			Description: "When true, runs an [initial snapshot scan](https://ydb.tech/docs/en/yql/reference/syntax/alter_table/changefeed) of the table when the changefeed is created. " +
+				"Only applies at creation; YDB does not expose this flag on describe, so Terraform keeps the configured value in state.",
+		},
 		"retention_period": {
 			Type:         schema.TypeString,
 			Description:  "Time of data retention in the topic, [ISO 8601](https://ru.wikipedia.org/wiki/ISO_8601) format.",


### PR DESCRIPTION
## Summary

Adds optional `initial_scan` to the `ydb_table_changefeed` resource so changefeeds can request an initial table snapshot at creation time, aligned with [YDB CDC / ALTER TABLE changefeed](https://ydb.tech/docs/en/yql/reference/syntax/alter_table/changefeed).

## Behaviour

- `initial_scan` is optional, defaults to `false`, and is **ForceNew** (YDB only runs the initial scan when the changefeed is created).
- When `true`, the provider emits `INITIAL_SCAN = TRUE` in the `ADD CHANGEFEED ... WITH (...)` scheme query.
- `DescribeTable` does not expose this flag on the changefeed description; on read/refresh we persist the configured value from state to avoid spurious drift.

## Tests

- Unit tests for `PrepareCreateRequest` with `initial_scan` on/off.

Closes https://github.com/ydb-platform/terraform-provider-ydb/issues/52

Made with [Cursor](https://cursor.com)