### PR TITLE
Add metrics_level attribute for ydb_topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,37 @@ This provider can be used for managing YDB schema resources in managed or on-pre
 - [ydb_external_data_source](./internal/resources/externaldatasource/README.md)
 - [ydb_external_table](./internal/resources/externaltable/README.md)
 - [ydb_secret](./internal/resources/secret/README.md)
+
+## Acceptance tests
+
+Acceptance tests live in `internal/terraform/` and run real Terraform plans against a YDB instance. They require:
+
+- `terraform` CLI on `PATH`
+- a running YDB endpoint (local Docker is fine — see below)
+- `TF_ACC=1` (required by the Terraform SDK to enable acceptance tests)
+- `YDB_ACC_CONNECTION_STRING` — full YDB connection string (e.g. `grpc://127.0.0.1:2136/?database=/local`)
+
+Optional provider auth env vars: `YDB_ACC_TOKEN`, `YDB_ACC_USER`, `YDB_ACC_PASSWORD`.
+
+### Spin up a local YDB
+
+```sh
+docker run -d --rm --name ydb-local \
+  -p 2135:2135 -p 2136:2136 -p 8765:8765 \
+  -e YDB_USE_IN_MEMORY_PDISKS=true \
+  ydbplatform/local-ydb:latest
+```
+
+### Run all acceptance tests
+
+```sh
+YDB_ACC_CONNECTION_STRING=grpc://127.0.0.1:2136/?database=/local TF_ACC=1 \
+  go test -v ./internal/terraform/ -run TestAcc -timeout 30m
+```
+
+### Run a single test
+
+```sh
+YDB_ACC_CONNECTION_STRING=grpc://127.0.0.1:2136/?database=/local TF_ACC=1 \
+  go test -v ./internal/terraform/ -run TestAccYdbTopic_metricsLevel -timeout 30m
+```

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
 	github.com/stretchr/testify v1.10.0
-	github.com/ydb-platform/ydb-go-sdk/v3 v3.134.0
+	github.com/ydb-platform/ydb-go-sdk/v3 v3.138.4
 	golang.org/x/crypto v0.48.0
 )
 
@@ -56,7 +56,7 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
-	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180
+	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -228,10 +228,10 @@ github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37w
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180 h1:avIdi8eGXjKbn1WLokNR1Ofnz1k8t7tJ88YQLD/iCi8=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
-github.com/ydb-platform/ydb-go-sdk/v3 v3.134.0 h1:Voog4d56wPNT8JQvbgN6QPdZ1gKG36YM5615PJB/XpM=
-github.com/ydb-platform/ydb-go-sdk/v3 v3.134.0/go.mod h1:VYUUkRJkKuQPkIpgtZJj6+58Fa2g8ccAqdmaaK6HP5k=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b h1:xeiobG1riqe6dTMZuTcOvwOY0BbFidSk3gRLyVeLfJA=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.138.4 h1:ovMIcaFkYo70XNXJyxUEEYtnhZENAVkoR/Tx++opsYw=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.138.4/go.mod h1:b9NEO6mgaiqsnOMkS003uS82XsKh6GL+ZTFfPqXWz+c=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/internal/terraform/ydb_topic_metrics_level_acc_test.go
+++ b/internal/terraform/ydb_topic_metrics_level_acc_test.go
@@ -1,0 +1,71 @@
+package terraform_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Acceptance tests for the ydb_topic metrics_level attribute (see acc_test.go for env and how to run).
+// Requires a YDB server with topic metrics_level support (server proto field added April 2026).
+
+func TestAccYdbTopic_metricsLevel(t *testing.T) {
+	conn := os.Getenv(envAccYDBConnection)
+	topicPath := "tf_acc_topic_metrics_" + accRandomHex8(t)
+
+	configWithLevel := func(level int) string {
+		return accTestConfigPrefix(conn) + fmt.Sprintf(`
+resource "ydb_topic" "test" {
+  database_endpoint = var.connection_string
+  name              = %q
+
+  metrics_level = %d
+}
+`, topicPath, level)
+	}
+
+	configWithoutLevel := accTestConfigPrefix(conn) + fmt.Sprintf(`
+resource "ydb_topic" "test" {
+  database_endpoint = var.connection_string
+  name              = %q
+}
+`, topicPath)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { accPreCheckYDB(t) },
+		ProviderFactories: accProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: configWithLevel(3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ydb_topic.test", "name", topicPath),
+					resource.TestCheckResourceAttrSet("ydb_topic.test", "id"),
+					resource.TestCheckResourceAttr("ydb_topic.test", "metrics_level", "3"),
+				),
+			},
+			{
+				Config: configWithLevel(5),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ydb_topic.test", "metrics_level", "5"),
+				),
+			},
+			{
+				// Removing metrics_level from HCL triggers AlterWithResetMetricsLevel,
+				// which reverts the topic to the database default (read back as 0).
+				Config: configWithoutLevel,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ydb_topic.test", "metrics_level", "0"),
+				),
+			},
+			{
+				// After a reset, metrics_level can be set again (AlterWithSetMetricsLevel).
+				Config: configWithLevel(7),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ydb_topic.test", "metrics_level", "7"),
+				),
+			},
+		},
+	})
+}

--- a/sdk/terraform/topic/attributes.go
+++ b/sdk/terraform/topic/attributes.go
@@ -24,4 +24,5 @@ const (
 	attributeStabilizationWindow                    = "stabilization_window"
 	attributeUpUtilizationPercent                   = "up_utilization_percent"
 	attributeDownUtilizationPercent                 = "down_utilization_percent"
+	attributeMetricsLevel                           = "metrics_level"
 )

--- a/sdk/terraform/topic/caller.go
+++ b/sdk/terraform/topic/caller.go
@@ -232,6 +232,9 @@ func (c *caller) resourceYDBTopicCreate(ctx context.Context, d *schema.ResourceD
 	if d.Get(attributeMeteringMode) != "" {
 		options = append(options, topicoptions.CreateWithMeteringMode(StringToMeteringMode(d.Get(attributeMeteringMode).(string))))
 	}
+	if v, ok := d.GetOk(attributeMetricsLevel); ok {
+		options = append(options, topicoptions.CreateWithMetricsLevel(uint32(v.(int))))
+	}
 	if d.Get(attributePartitionWriteSpeedKBPS) != 0 {
 		writeSpeed := 1024 * d.Get(attributePartitionWriteSpeedKBPS).(int)
 		options = append(options, topicoptions.CreateWithPartitionWriteBurstBytes(int64(writeSpeed)))

--- a/sdk/terraform/topic/resource.go
+++ b/sdk/terraform/topic/resource.go
@@ -234,6 +234,11 @@ func ResourceSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Computed:    true,
 		},
+		attributeMetricsLevel: {
+			Type:        schema.TypeInt,
+			Description: "Topic metrics level. If unset (or 0), the database default is used.",
+			Optional:    true,
+		},
 		attributeAutoPartitioningSettings: {
 			Type:     schema.TypeList,
 			Optional: true,

--- a/sdk/terraform/topic/structures_manual.go
+++ b/sdk/terraform/topic/structures_manual.go
@@ -20,6 +20,11 @@ func flattenYDBTopicDescription(d *schema.ResourceData, desc topictypes.TopicDes
 	_ = d.Set(attributeRetentionPeriodHours, desc.RetentionPeriod.Hours())
 	_ = d.Set(attributeRetentionStorageMB, desc.RetentionStorageMB)
 	_ = d.Set(attributeMeteringMode, MeteringModeToString(desc.MeteringMode))
+	if desc.MetricsLevel != nil {
+		_ = d.Set(attributeMetricsLevel, int(*desc.MetricsLevel))
+	} else {
+		_ = d.Set(attributeMetricsLevel, 0)
+	}
 	_ = d.Set(attributePartitionWriteSpeedKBPS, desc.PartitionWriteSpeedBytesPerSecond/1024)
 	_ = d.Set(attributeAutoPartitioningSettings, []map[string]interface{}{
 		{
@@ -73,6 +78,13 @@ func prepareYDBTopicAlterSettings(
 	}
 	if d.HasChange(attributeMeteringMode) {
 		opts = append(opts, topicoptions.AlterWithMeteringMode(StringToMeteringMode(d.Get("metering_mode").(string))))
+	}
+	if d.HasChange(attributeMetricsLevel) {
+		if v, ok := d.GetOk(attributeMetricsLevel); ok {
+			opts = append(opts, topicoptions.AlterWithSetMetricsLevel(uint32(v.(int))))
+		} else {
+			opts = append(opts, topicoptions.AlterWithResetMetricsLevel())
+		}
 	}
 	if d.HasChange(attributeSupportedCodecs) {
 		codecs := d.Get(attributeSupportedCodecs).(*schema.Set)


### PR DESCRIPTION
## Summary
- Adds `metrics_level` (`TypeInt`, `Optional`) to the `ydb_topic` resource schema. Wires create / alter / read through the new SDK options.
- On create: a non-zero value goes via `topicoptions.CreateWithMetricsLevel`. On update: non-zero ⇒ `AlterWithSetMetricsLevel`, zero or attribute removed from HCL ⇒ `AlterWithResetMetricsLevel`. On read: SDK's `*uint32` (`nil` = database default) maps back to `0`, so removing the attribute is the idempotent "use database default" path.
- Bumps `ydb-go-sdk/v3` to `v3.138.4` (release containing the feature) — `ydb-go-genproto` is pulled transitively.

## Test plan
- [x] `go build ./...` and `go vet ./sdk/terraform/topic/... ./internal/helpers/topic/...` are clean
- [x] `go test -c ./internal/terraform/` compiles the new acc test
- [x] `TestAccYdbTopic_metricsLevel` covers create with `metrics_level = 3` → update to `5` → remove from HCL (reset) → set to `7` against a local YDB
- [x] README updated with an "Acceptance tests" section documenting required env vars (`TF_ACC=1`, `YDB_ACC_CONNECTION_STRING`, optional auth vars), a `docker run` snippet for a local YDB, and how to run all / a single acc test

🤖 Generated with [Claude Code](https://claude.com/claude-code)