### PR TITLE
Support in-place updates for ydb_external_data_source

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         image: ydbplatform/local-ydb:edge
         options: --hostname localhost
         env:
-          YDB_FEATURE_FLAGS: enable_external_data_sources
+          YDB_FEATURE_FLAGS: enable_external_data_sources,enable_replace_if_exists_for_external_entities
         ports:
           - 2136:2136
     env:

--- a/internal/resources/externaldatasource/README.md
+++ b/internal/resources/externaldatasource/README.md
@@ -2,7 +2,7 @@
 
 `ydb_external_data_source` resource is used to manage YDB [external data source](https://ydb.tech/docs/ru/concepts/datamodel/external_data_source) entity.
 
-All attributes are immutable. Any change triggers resource recreation (drop + create).
+Configuration changes are applied in place via `CREATE OR REPLACE EXTERNAL DATA SOURCE`. Only `connection_string` and `path` require resource recreation.
 
 ## Example
 

--- a/internal/resources/externaldatasource/create.go
+++ b/internal/resources/externaldatasource/create.go
@@ -32,7 +32,7 @@ func (h *Handler) Create(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	fullPath := databaseURL.Query().Get("database") + "/" + r.Path
 
-	q := PrepareCreateQuery(fullPath, r)
+	q := PrepareDataSourceQuery(fullPath, r)
 	err = db.Query().Exec(ctx, q)
 	if err != nil {
 		return diag.Errorf("failed to create external data source: %s", err)

--- a/internal/resources/externaldatasource/update.go
+++ b/internal/resources/externaldatasource/update.go
@@ -5,8 +5,36 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/ydb-platform/terraform-provider-ydb/internal/helpers"
+	tbl "github.com/ydb-platform/terraform-provider-ydb/internal/table"
 )
 
-func (h *Handler) Update(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	return diag.Errorf("update is not supported for external data source, all changes require recreation")
+func (h *Handler) Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	r, err := resourceSchemaToResource(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	entity, err := helpers.ParseYDBEntityID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	db, err := tbl.CreateDBConnection(ctx, tbl.ClientParams{
+		DatabaseEndpoint: entity.PrepareFullYDBEndpoint(),
+		AuthCreds:        h.authCreds,
+	})
+	if err != nil {
+		return diag.Errorf("failed to initialize client: %s", err)
+	}
+	defer func() { _ = db.Close(ctx) }()
+
+	q := PrepareDataSourceQuery(entity.GetFullEntityPath(), r)
+	err = db.Query().Exec(ctx, q)
+	if err != nil {
+		return diag.Errorf("failed to update external data source: %s", err)
+	}
+
+	return h.Read(ctx, d, meta)
 }

--- a/internal/resources/externaldatasource/yql.go
+++ b/internal/resources/externaldatasource/yql.go
@@ -42,9 +42,9 @@ func appendWithClause(buf []byte, params []withParam) []byte {
 	return buf
 }
 
-func PrepareCreateQuery(fullPath string, r *Resource) string {
+func PrepareDataSourceQuery(fullPath string, r *Resource) string {
 	buf := make([]byte, 0, 512)
-	buf = append(buf, "CREATE EXTERNAL DATA SOURCE `"...)
+	buf = append(buf, "CREATE OR REPLACE EXTERNAL DATA SOURCE `"...)
 	buf = append(buf, fullPath...)
 	buf = append(buf, '`')
 	buf = appendWithClause(buf, collectWithParams(r))

--- a/internal/resources/externaldatasource/yql_test.go
+++ b/internal/resources/externaldatasource/yql_test.go
@@ -8,7 +8,7 @@ import (
 
 func boolPtr(b bool) *bool { return &b }
 
-func TestPrepareCreateQuery(t *testing.T) {
+func TestPrepareDataSourceQuery(t *testing.T) {
 	testData := []struct {
 		testName string
 		fullPath string
@@ -22,7 +22,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				"source_type": "ObjectStorage",
 				"location":    "localhost:12345",
 			}},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/my_source`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/my_source`" +
 				` WITH ( SOURCE_TYPE = "ObjectStorage", LOCATION = "localhost:12345" )`,
 		},
 		{
@@ -33,7 +33,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				"location":    "s3.amazonaws.com",
 				"auth_method": "NONE",
 			}},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/s3_source`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/s3_source`" +
 				` WITH ( SOURCE_TYPE = "ObjectStorage", LOCATION = "s3.amazonaws.com", AUTH_METHOD = "NONE" )`,
 		},
 		{
@@ -51,7 +51,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				},
 				UseTLS: boolPtr(true),
 			},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/ch_source`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/ch_source`" +
 				` WITH ( SOURCE_TYPE = "ClickHouse", LOCATION = "clickhouse-host:9000",` +
 				` AUTH_METHOD = "BASIC", LOGIN = "user", PASSWORD_SECRET_PATH = "/local/my_password_secret",` +
 				` DATABASE_NAME = "default", PROTOCOL = "NATIVE", USE_TLS = "TRUE" )`,
@@ -66,7 +66,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				"service_account_id":          "sa-id-123",
 				"service_account_secret_path": "/local/sa_secret",
 			}},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/sa_source`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/sa_source`" +
 				` WITH ( SOURCE_TYPE = "ObjectStorage", LOCATION = "storage.yandexcloud.net",` +
 				` AUTH_METHOD = "SERVICE_ACCOUNT", SERVICE_ACCOUNT_ID = "sa-id-123",` +
 				` SERVICE_ACCOUNT_SECRET_PATH = "/local/sa_secret" )`,
@@ -82,7 +82,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				"aws_secret_access_key_secret_path": "/local/aws_secret_key",
 				"aws_region":                        "us-east-1",
 			}},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/aws_source`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/aws_source`" +
 				` WITH ( SOURCE_TYPE = "ObjectStorage", LOCATION = "s3.us-east-1.amazonaws.com",` +
 				` AUTH_METHOD = "AWS", AWS_ACCESS_KEY_ID_SECRET_PATH = "/local/aws_key_id",` +
 				` AWS_SECRET_ACCESS_KEY_SECRET_PATH = "/local/aws_secret_key", AWS_REGION = "us-east-1" )`,
@@ -102,7 +102,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				},
 				UseTLS: boolPtr(true),
 			},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/mdb_source`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/mdb_source`" +
 				` WITH ( SOURCE_TYPE = "PostgreSQL", LOCATION = "rc1a-xxx.mdb.yandexcloud.net:6432",` +
 				` AUTH_METHOD = "MDB_BASIC", LOGIN = "pguser", PASSWORD_SECRET_PATH = "/local/pg_pass",` +
 				` DATABASE_NAME = "mydb", MDB_CLUSTER_ID = "c9q1234567890", USE_TLS = "TRUE" )`,
@@ -115,7 +115,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				"location":    "localhost:12345",
 				"auth_method": "NONE",
 			}},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/minimal`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/minimal`" +
 				` WITH ( SOURCE_TYPE = "ObjectStorage", LOCATION = "localhost:12345", AUTH_METHOD = "NONE" )`,
 		},
 		{
@@ -134,7 +134,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				},
 				UseTLS: boolPtr(true),
 			},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/pg_source`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/pg_source`" +
 				` WITH ( SOURCE_TYPE = "PostgreSQL", LOCATION = "localhost:5432",` +
 				` AUTH_METHOD = "BASIC", LOGIN = "pguser", PASSWORD_SECRET_PATH = "/local/pg_pass",` +
 				` DATABASE_NAME = "mydb", PROTOCOL = "NATIVE", SCHEMA = "public", USE_TLS = "TRUE" )`,
@@ -151,7 +151,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				"database_name":        "ORCL",
 				"service_name":         "my_service",
 			}},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/oracle_source`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/oracle_source`" +
 				` WITH ( SOURCE_TYPE = "Oracle", LOCATION = "localhost:1521",` +
 				` AUTH_METHOD = "BASIC", LOGIN = "orauser", PASSWORD_SECRET_PATH = "/local/ora_pass",` +
 				` DATABASE_NAME = "ORCL", SERVICE_NAME = "my_service" )`,
@@ -171,7 +171,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				},
 				UseTLS: boolPtr(true),
 			},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/solomon_source`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/solomon_source`" +
 				` WITH ( SOURCE_TYPE = "Solomon", LOCATION = "localhost:9090",` +
 				` AUTH_METHOD = "TOKEN", TOKEN_SECRET_PATH = "/local/tok",` +
 				` GRPC_LOCATION = "vla", PROJECT = "myproject",` +
@@ -187,7 +187,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				"database_name": "mydb",
 				"database_id":   "etn123",
 			}},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/ydb_source`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/ydb_source`" +
 				` WITH ( SOURCE_TYPE = "Ydb", LOCATION = "localhost:2136",` +
 				` AUTH_METHOD = "NONE", DATABASE_NAME = "mydb",` +
 				` DATABASE_ID = "etn123" )`,
@@ -203,7 +203,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 				"service_account_secret_path": "/local/sa_secret",
 				"folder_id":                   "b1g456",
 			}},
-			expected: `CREATE EXTERNAL DATA SOURCE ` + "`/local/logging_source`" +
+			expected: `CREATE OR REPLACE EXTERNAL DATA SOURCE ` + "`/local/logging_source`" +
 				` WITH ( SOURCE_TYPE = "Logging", LOCATION = "localhost:8080",` +
 				` AUTH_METHOD = "SERVICE_ACCOUNT", SERVICE_ACCOUNT_ID = "sa123",` +
 				` SERVICE_ACCOUNT_SECRET_PATH = "/local/sa_secret", FOLDER_ID = "b1g456" )`,
@@ -212,7 +212,7 @@ func TestPrepareCreateQuery(t *testing.T) {
 
 	for _, v := range testData {
 		t.Run(v.testName, func(t *testing.T) {
-			got := PrepareCreateQuery(v.fullPath, v.resource)
+			got := PrepareDataSourceQuery(v.fullPath, v.resource)
 			assert.Equal(t, v.expected, got)
 		})
 	}

--- a/internal/terraform/external_data_source.go
+++ b/internal/terraform/external_data_source.go
@@ -17,6 +17,7 @@ func ydbExternalDataSourceResource() *schema.Resource {
 		SchemaVersion: 0,
 		CreateContext: resourceYDBExternalDataSourceCreate,
 		ReadContext:   resourceYDBExternalDataSourceRead,
+		UpdateContext: resourceYDBExternalDataSourceUpdate,
 		DeleteContext: resourceYDBExternalDataSourceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -53,6 +54,14 @@ func resourceYDBExternalDataSourceRead(ctx context.Context, d *schema.ResourceDa
 		return cfg.AuthCreds, nil
 	}
 	return eds.ResourceReadFunc(cb)(ctx, d, meta)
+}
+
+func resourceYDBExternalDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*Config)
+	cb := func(ctx context.Context) (auth.YdbCredentials, error) {
+		return cfg.AuthCreds, nil
+	}
+	return eds.ResourceUpdateFunc(cb)(ctx, d, meta)
 }
 
 func resourceYDBExternalDataSourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/terraform/ydb_external_acc_test.go
+++ b/internal/terraform/ydb_external_acc_test.go
@@ -63,10 +63,17 @@ resource "ydb_external_data_source" "with_secret" {
 	})
 }
 
-func TestAccYdbExternalDataSource_objectStorageNone(t *testing.T) {
+// TestAccYdbExternalDataSource_updateInPlaceWithDependentTable verifies that EDS
+// configuration is updated via CREATE OR REPLACE while an external table references it.
+// A destroy-and-create update (ForceNew) would fail: YDB rejects dropping an external
+// data source that has dependent external tables.
+func TestAccYdbExternalDataSource_updateInPlaceWithDependentTable(t *testing.T) {
 	conn := os.Getenv(envAccYDBConnection)
 	suffix := accRandomHex8(t)
-	path := "tf_acc_ext/ds_" + suffix
+	dsPath := "tf_acc_ext/ds_" + suffix
+	tblPath := "tf_acc_ext/tbl_" + suffix
+	locInitial := "https://example.com/terraform-acc-bucket/"
+	locUpdated := "https://example.com/terraform-acc-bucket-updated/"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { accPreCheckYDB(t) },
@@ -78,14 +85,68 @@ resource "ydb_external_data_source" "test" {
   connection_string = var.connection_string
   path                = %q
   source_type         = "ObjectStorage"
-  location            = "https://example.com/terraform-acc-bucket/"
+  location            = %q
   auth_method         = "NONE"
 }
-`, path),
+
+resource "ydb_external_table" "dependent" {
+  connection_string  = var.connection_string
+  path                 = %q
+  data_source_path     = ydb_external_data_source.test.path
+  location             = "prefix/"
+  format               = "csv_with_names"
+
+  column {
+    name = "key"
+    type = "Utf8"
+  }
+  column {
+    name = "value"
+    type = "Utf8"
+  }
+}
+`, dsPath, locInitial, tblPath),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ydb_external_data_source.test", "path", path),
+					resource.TestCheckResourceAttr("ydb_external_data_source.test", "path", dsPath),
 					resource.TestCheckResourceAttr("ydb_external_data_source.test", "source_type", "ObjectStorage"),
+					resource.TestCheckResourceAttr("ydb_external_data_source.test", "location", locInitial),
 					resource.TestCheckResourceAttrSet("ydb_external_data_source.test", "id"),
+					resource.TestCheckResourceAttr("ydb_external_table.dependent", "path", tblPath),
+					resource.TestCheckResourceAttrPair("ydb_external_table.dependent", "data_source_path", "ydb_external_data_source.test", "path"),
+					resource.TestCheckResourceAttrSet("ydb_external_table.dependent", "id"),
+				),
+			},
+			{
+				Config: accTestConfigPrefix(conn) + fmt.Sprintf(`
+resource "ydb_external_data_source" "test" {
+  connection_string = var.connection_string
+  path                = %q
+  source_type         = "ObjectStorage"
+  location            = %q
+  auth_method         = "NONE"
+}
+
+resource "ydb_external_table" "dependent" {
+  connection_string  = var.connection_string
+  path                 = %q
+  data_source_path     = ydb_external_data_source.test.path
+  location             = "prefix/"
+  format               = "csv_with_names"
+
+  column {
+    name = "key"
+    type = "Utf8"
+  }
+  column {
+    name = "value"
+    type = "Utf8"
+  }
+}
+`, dsPath, locUpdated, tblPath),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ydb_external_data_source.test", "location", locUpdated),
+					resource.TestCheckResourceAttr("ydb_external_table.dependent", "path", tblPath),
+					resource.TestCheckResourceAttrPair("ydb_external_table.dependent", "data_source_path", "ydb_external_data_source.test", "path"),
 				),
 			},
 		},

--- a/sdk/terraform/externaldatasource/resource.go
+++ b/sdk/terraform/externaldatasource/resource.go
@@ -51,6 +51,19 @@ func DataSourceReadFunc(cb auth.GetAuthCallback) helpers.TerraformCRUD {
 	}
 }
 
+func ResourceUpdateFunc(cb auth.GetAuthCallback) helpers.TerraformCRUD {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		authCreds, err := cb(ctx)
+		if err != nil {
+			return diag.Diagnostics{
+				{Severity: diag.Error, Summary: "failed to create token for YDB request", Detail: err.Error()},
+			}
+		}
+		h := externaldatasource.NewHandler(authCreds)
+		return h.Update(ctx, d, meta)
+	}
+}
+
 func ResourceDeleteFunc(cb auth.GetAuthCallback) helpers.TerraformCRUD {
 	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		authCreds, err := cb(ctx)
@@ -105,154 +118,129 @@ func ResourceSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Description:  "Type of the external data source (e.g. ObjectStorage, Ydb, ClickHouse, PostgreSQL).",
 			Required:     true,
-			ForceNew:     true,
 			ValidateFunc: validation.StringInSlice(externalDataSourceSourceTypes, false),
 		},
 		"location": {
 			Type:        schema.TypeString,
 			Description: "Network address of the external data source.",
 			Required:    true,
-			ForceNew:    true,
 		},
 		"auth_method": {
 			Type:             schema.TypeString,
 			Description:      "Authentication method (NONE, BASIC, MDB_BASIC, AWS, TOKEN, SERVICE_ACCOUNT).",
 			Optional:         true,
-			ForceNew:         true,
 			ValidateDiagFunc: optionalEnum(externalDataSourceAuthMethods),
 		},
 		"login": {
 			Type:        schema.TypeString,
 			Description: "Login for BASIC/MDB_BASIC authentication.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"password_secret_path": {
 			Type:        schema.TypeString,
 			Description: "Secret path for the password.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"service_account_id": {
 			Type:        schema.TypeString,
 			Description: "Service account ID.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"service_account_secret_path": {
 			Type:        schema.TypeString,
 			Description: "Secret path for service account authentication.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"aws_access_key_id_secret_path": {
 			Type:        schema.TypeString,
 			Description: "Secret path for AWS access key ID.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"aws_secret_access_key_secret_path": {
 			Type:        schema.TypeString,
 			Description: "Secret path for AWS secret access key.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"aws_region": {
 			Type:        schema.TypeString,
 			Description: "AWS region.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"token_secret_path": {
 			Type:        schema.TypeString,
 			Description: "Secret path for TOKEN authentication.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"database_name": {
 			Type:        schema.TypeString,
 			Description: "Database name in the external data source.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"protocol": {
 			Type:             schema.TypeString,
 			Description:      "Communication protocol (NATIVE, HTTP).",
 			Optional:         true,
-			ForceNew:         true,
 			ValidateDiagFunc: optionalEnum(externalDataSourceProtocols),
 		},
 		"use_tls": {
 			Type:        schema.TypeBool,
 			Description: "Whether to use TLS in the external data source connection.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"mdb_cluster_id": {
 			Type:        schema.TypeString,
 			Description: "Managed Database cluster ID.",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"schema": {
 			Type:        schema.TypeString,
 			Description: "Schema name (for PostgreSQL, Greenplum).",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"service_name": {
 			Type:        schema.TypeString,
 			Description: "Service name (for Oracle).",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"folder_id": {
 			Type:        schema.TypeString,
 			Description: "Folder ID (for Logging).",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"grpc_location": {
 			Type:        schema.TypeString,
 			Description: "gRPC location (for Solomon).",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"project": {
 			Type:        schema.TypeString,
 			Description: "Project name (for Solomon).",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"cluster": {
 			Type:        schema.TypeString,
 			Description: "Cluster name (for Solomon).",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"database_id": {
 			Type:        schema.TypeString,
 			Description: "Database ID (for Ydb).",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"reading_mode": {
 			Type:        schema.TypeString,
 			Description: "Reading mode (for MongoDB).",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"unexpected_type_display_mode": {
 			Type:        schema.TypeString,
 			Description: "Unexpected type display mode (for MongoDB).",
 			Optional:    true,
-			ForceNew:    true,
 		},
 		"unsupported_type_display_mode": {
 			Type:        schema.TypeString,
 			Description: "Unsupported type display mode (for MongoDB).",
 			Optional:    true,
-			ForceNew:    true,
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- Add `Update` for `ydb_external_data_source` using `CREATE OR REPLACE EXTERNAL DATA SOURCE` instead of `ForceNew` recreation.
- Remove `ForceNew` from mutable attributes; only `connection_string` and `path` still require recreation.
- Unify create and update YQL generation via `PrepareDataSourceQuery`.
- Add acceptance test that updates an EDS while a dependent `ydb_external_table` exists (recreate would fail because YDB rejects dropping a referenced EDS).

## Test plan
- [x] `go test ./internal/resources/externaldatasource/... -run TestPrepare`
- [ ] `TF_ACC=1 YDB_ACC_CONNECTION_STRING=... go test -v ./internal/terraform/ -run TestAccYdbExternalDataSource_updateInPlaceWithDependentTable -timeout 30m`


Made with [Cursor](https://cursor.com)