### PR TITLE
Keep ForceNew on source_type for ydb_external_data_source

### DIFF
--- a/internal/resources/externaldatasource/README.md
+++ b/internal/resources/externaldatasource/README.md
@@ -2,7 +2,7 @@
 
 `ydb_external_data_source` resource is used to manage YDB [external data source](https://ydb.tech/docs/ru/concepts/datamodel/external_data_source) entity.
 
-Configuration changes are applied in place via `CREATE OR REPLACE EXTERNAL DATA SOURCE`. Only `connection_string` and `path` require resource recreation.
+Configuration changes are applied in place via `CREATE OR REPLACE EXTERNAL DATA SOURCE`. Only `connection_string`, `path`, and `source_type` require resource recreation.
 
 ## Example
 

--- a/internal/terraform/ydb_external_acc_test.go
+++ b/internal/terraform/ydb_external_acc_test.go
@@ -153,6 +153,51 @@ resource "ydb_external_table" "dependent" {
 	})
 }
 
+// TestAccYdbExternalDataSource_sourceTypeRequiresReplacement verifies that changing
+// source_type is applied via ForceNew (destroy + create), not an in-place update.
+func TestAccYdbExternalDataSource_sourceTypeRequiresReplacement(t *testing.T) {
+	conn := os.Getenv(envAccYDBConnection)
+	suffix := accRandomHex8(t)
+	dsPath := "tf_acc_ext/ds_st_" + suffix
+	ydbLoc := accLocationHostPortFromConn(conn)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { accPreCheckYDB(t) },
+		ProviderFactories: accProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: accTestConfigPrefix(conn) + fmt.Sprintf(`
+resource "ydb_external_data_source" "test" {
+  connection_string = var.connection_string
+  path                = %q
+  source_type         = "ObjectStorage"
+  location            = "https://example.com/terraform-acc-bucket/"
+  auth_method         = "NONE"
+}
+`, dsPath),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ydb_external_data_source.test", "source_type", "ObjectStorage"),
+				),
+			},
+			{
+				Config: accTestConfigPrefix(conn) + fmt.Sprintf(`
+resource "ydb_external_data_source" "test" {
+  connection_string = var.connection_string
+  path                = %q
+  source_type         = "Ydb"
+  location            = %q
+  auth_method         = "NONE"
+}
+`, dsPath, ydbLoc),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ydb_external_data_source.test", "source_type", "Ydb"),
+					resource.TestCheckResourceAttr("ydb_external_data_source.test", "location", ydbLoc),
+				),
+			},
+		},
+	})
+}
+
 func TestAccYdbExternalTable_withDataSource(t *testing.T) {
 	conn := os.Getenv(envAccYDBConnection)
 	suffix := accRandomHex8(t)

--- a/sdk/terraform/externaldatasource/resource.go
+++ b/sdk/terraform/externaldatasource/resource.go
@@ -118,6 +118,7 @@ func ResourceSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Description:  "Type of the external data source (e.g. ObjectStorage, Ydb, ClickHouse, PostgreSQL).",
 			Required:     true,
+			ForceNew:     true,
 			ValidateFunc: validation.StringInSlice(externalDataSourceSourceTypes, false),
 		},
 		"location": {


### PR DESCRIPTION
## Summary
- Restore `ForceNew` on `source_type` so changing the type recreates the resource instead of an in-place `CREATE OR REPLACE`.
- Update README to list `source_type` among attributes that require recreation.
- Add acceptance test `TestAccYdbExternalDataSource_sourceTypeRequiresReplacement` (ObjectStorage → Ydb).

## Test plan
- [ ] `TF_ACC=1 YDB_ACC_CONNECTION_STRING=... go test -v ./internal/terraform/ -run TestAccYdbExternalDataSource_sourceTypeRequiresReplacement -timeout 30m`


Made with [Cursor](https://cursor.com)