### PR TITLE
Fix external table column type drift and EDS update parsing

### DIFF
--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -218,3 +218,20 @@ func AreAllElementsUnique(consumers []topictypes.Consumer) error {
 	}
 	return nil
 }
+
+// NormalizeYQLColumnType canonicalizes a YQL column type for Terraform state and config comparison.
+// YDB may return PascalCase (e.g. Int32, String) while users often write lowercase in HCL.
+func NormalizeYQLColumnType(typ string) string {
+	return strings.ToLower(strings.TrimSpace(typ))
+}
+
+// NormalizeYQLColumnTypeState is a schema.StateFunc for column type attributes.
+func NormalizeYQLColumnTypeState(v interface{}) string {
+	s, _ := v.(string)
+	return NormalizeYQLColumnType(s)
+}
+
+// SuppressYQLColumnTypeCaseDiff suppresses plan diffs that differ only by YQL type letter case.
+func SuppressYQLColumnTypeCaseDiff(_, old, newVal string, _ *schema.ResourceData) bool {
+	return strings.EqualFold(strings.TrimSpace(old), strings.TrimSpace(newVal))
+}

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -270,3 +270,11 @@ func TestJoinRelativizeYDBCatalogPathRoundTrip(t *testing.T) {
 	assert.Equal(t, "/local/tf_acc_ext/tok_1", abs)
 	assert.Equal(t, rel, RelativizeYDBCatalogPath(root, abs))
 }
+
+func TestNormalizeYQLColumnType(t *testing.T) {
+	assert.Equal(t, "int32", NormalizeYQLColumnType("Int32"))
+	assert.Equal(t, "string", NormalizeYQLColumnType(" String "))
+	assert.Equal(t, "utf8", NormalizeYQLColumnType("Utf8"))
+	assert.True(t, SuppressYQLColumnTypeCaseDiff("", "Int32", "int32", nil))
+	assert.False(t, SuppressYQLColumnTypeCaseDiff("", "Int32", "utf8", nil))
+}

--- a/internal/resources/externaldatasource/update.go
+++ b/internal/resources/externaldatasource/update.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/ydb-platform/terraform-provider-ydb/internal/helpers"
 	tbl "github.com/ydb-platform/terraform-provider-ydb/internal/table"
 )
 
@@ -16,13 +15,12 @@ func (h *Handler) Update(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 
-	entity, err := helpers.ParseYDBEntityID(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
+	if r.Entity == nil {
+		return diag.Errorf("external data source id is required for update")
 	}
 
 	db, err := tbl.CreateDBConnection(ctx, tbl.ClientParams{
-		DatabaseEndpoint: entity.PrepareFullYDBEndpoint(),
+		DatabaseEndpoint: r.getConnectionString(),
 		AuthCreds:        h.authCreds,
 	})
 	if err != nil {
@@ -30,7 +28,7 @@ func (h *Handler) Update(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	defer func() { _ = db.Close(ctx) }()
 
-	q := PrepareDataSourceQuery(entity.GetFullEntityPath(), r)
+	q := PrepareDataSourceQuery(r.Entity.GetFullEntityPath(), r)
 	err = db.Query().Exec(ctx, q)
 	if err != nil {
 		return diag.Errorf("failed to update external data source: %s", err)

--- a/internal/resources/externaltable/external_table.go
+++ b/internal/resources/externaltable/external_table.go
@@ -84,7 +84,7 @@ func parseColumns(d *schema.ResourceData) []ColumnDef {
 		m := raw.(map[string]interface{})
 		columns = append(columns, ColumnDef{
 			Name:    m["name"].(string),
-			Type:    m["type"].(string),
+			Type:    helpers.NormalizeYQLColumnType(m["type"].(string)),
 			NotNull: m["not_null"].(bool),
 		})
 	}
@@ -101,7 +101,7 @@ func unwrapType(t types.Type) (typ string, notNull bool) {
 		yqlStr = strings.TrimSuffix(yqlStr, ">")
 	}
 
-	return yqlStr, notNull
+	return helpers.NormalizeYQLColumnType(yqlStr), notNull
 }
 
 // normalizeYdbContentScalar unwraps Describe values such as ["csv_with_names"] to csv_with_names.

--- a/internal/resources/externaltable/external_table_normalize_test.go
+++ b/internal/resources/externaltable/external_table_normalize_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/ydb-platform/ydb-go-sdk/v3/table/types"
 )
 
 func TestNormalizeYdbContentScalar(t *testing.T) {
@@ -11,4 +12,14 @@ func TestNormalizeYdbContentScalar(t *testing.T) {
 	assert.Equal(t, "gzip", normalizeYdbContentScalar(`["gzip"]`))
 	assert.Equal(t, "parquet", normalizeYdbContentScalar("parquet"))
 	assert.Equal(t, `["a","b"]`, normalizeYdbContentScalar(`["a","b"]`))
+}
+
+func TestUnwrapTypeNormalizesCase(t *testing.T) {
+	typ, notNull := unwrapType(types.TypeUTF8)
+	assert.Equal(t, "utf8", typ)
+	assert.True(t, notNull)
+
+	typ, notNull = unwrapType(types.Optional(types.TypeInt32))
+	assert.Equal(t, "int32", typ)
+	assert.False(t, notNull)
 }

--- a/internal/terraform/ydb_external_acc_test.go
+++ b/internal/terraform/ydb_external_acc_test.go
@@ -198,18 +198,16 @@ resource "ydb_external_data_source" "test" {
 	})
 }
 
+// TestAccYdbExternalTable_withDataSource creates an external table backed by an EDS, then
+// re-plans the same config. Column types are lowercase in HCL; YDB Describe returns
+// PascalCase — Read must normalize so the second plan is empty.
 func TestAccYdbExternalTable_withDataSource(t *testing.T) {
 	conn := os.Getenv(envAccYDBConnection)
 	suffix := accRandomHex8(t)
 	dsPath := "tf_acc_ext/ds_" + suffix
 	tblPath := "tf_acc_ext/tbl_" + suffix
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { accPreCheckYDB(t) },
-		ProviderFactories: accProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: accTestConfigPrefix(conn) + fmt.Sprintf(`
+	config := accTestConfigPrefix(conn) + fmt.Sprintf(`
 resource "ydb_external_data_source" "s3" {
   connection_string = var.connection_string
   path                = %q
@@ -226,21 +224,42 @@ resource "ydb_external_table" "test" {
   format               = "csv_with_names"
 
   column {
-    name = "key"
-    type = "Utf8"
+    name     = "id"
+    type     = "int32"
+    not_null = true
+  }
+  column {
+    name = "name"
+    type = "string"
+  }
+  column {
+    name     = "key"
+    type     = "utf8"
+    not_null = true
   }
   column {
     name = "value"
     type = "Utf8"
   }
 }
-`, dsPath, tblPath),
+`, dsPath, tblPath)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { accPreCheckYDB(t) },
+		ProviderFactories: accProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ydb_external_table.test", "path", tblPath),
 					resource.TestCheckResourceAttrPair("ydb_external_table.test", "data_source_path", "ydb_external_data_source.s3", "path"),
 					resource.TestCheckResourceAttr("ydb_external_table.test", "format", "csv_with_names"),
 					resource.TestCheckResourceAttrSet("ydb_external_table.test", "id"),
 				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
 			},
 		},
 	})

--- a/sdk/terraform/externaltable/resource.go
+++ b/sdk/terraform/externaltable/resource.go
@@ -102,10 +102,12 @@ func ResourceSchema() map[string]*schema.Schema {
 						ValidateFunc: validation.NoZeroValues,
 					},
 					"type": {
-						Type:         schema.TypeString,
-						Description:  "Column data type (YQL type).",
-						Required:     true,
-						ValidateFunc: validation.NoZeroValues,
+						Type:             schema.TypeString,
+						Description:      "Column data type (YQL type).",
+						Required:         true,
+						ValidateFunc:     validation.NoZeroValues,
+						StateFunc:        helpers.NormalizeYQLColumnTypeState,
+						DiffSuppressFunc: helpers.SuppressYQLColumnTypeCaseDiff,
 					},
 					"not_null": {
 						Type:        schema.TypeBool,


### PR DESCRIPTION
## Summary

- Normalize `ydb_external_table` column `type` to lowercase on Read and via `StateFunc` / `DiffSuppressFunc`, so YDB PascalCase (`Int32`, `String`, `Utf8`) does not drift against lowercase HCL (`int32`, `string`, `utf8`).
- Extend `TestAccYdbExternalTable_withDataSource` with mixed-case column types and a second `PlanOnly` step to ensure the re-plan is empty.
- Remove duplicate `ParseYDBEntityID` in `ydb_external_data_source` Update; use `r.Entity` and `r.getConnectionString()` from `resourceSchemaToResource`.

## Test plan

- [x] `go test ./internal/helpers/... ./internal/resources/externaltable/...`
- [ ] `TF_ACC=1 go test -v ./internal/terraform/ -run TestAccYdbExternalTable_withDataSource -timeout 30m` (requires YDB)


Made with [Cursor](https://cursor.com)