### PR TITLE
Reject ydb_table column type changes at plan time

### DIFF
--- a/internal/resources/table/table_diff.go
+++ b/internal/resources/table/table_diff.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -19,10 +20,20 @@ type tableDiff struct {
 	OnlyResetTTL              bool
 }
 
+func validateExistingColumnChange(name string, oldCol, newCol *Column) error {
+	if oldCol.Type != newCol.Type {
+		return fmt.Errorf(
+			"changing column %q type from %q to %q is not supported: YDB does not allow in-place column type changes",
+			name, oldCol.Type, newCol.Type,
+		)
+	}
+	return nil
+}
+
 func checkColumnDiff(rcolumns []*Column, dcolumns []*Column) ([]*Column, error) {
-	existingColumns := make(map[string]struct{})
+	existingColumns := make(map[string]*Column)
 	for _, v := range dcolumns {
-		existingColumns[v.Name] = struct{}{}
+		existingColumns[v.Name] = v
 	}
 	resourceColumns := make(map[string]*Column)
 	for _, v := range rcolumns {
@@ -38,6 +49,14 @@ func checkColumnDiff(rcolumns []*Column, dcolumns []*Column) ([]*Column, error) 
 		}
 	}
 
+	for name, newCol := range resourceColumns {
+		if oldCol, ok := existingColumns[name]; ok {
+			if err := validateExistingColumnChange(name, oldCol, newCol); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	for k, v := range resourceColumns {
 		if _, ok := existingColumns[k]; !ok {
 			columnsToAdd = append(columnsToAdd, v)
@@ -48,6 +67,19 @@ func checkColumnDiff(rcolumns []*Column, dcolumns []*Column) ([]*Column, error) 
 		return nil, fmt.Errorf("it is prohibited to delete columns with terraform. Columns for deletion: [%s]", strings.Join(deletedColumns, ","))
 	}
 	return columnsToAdd, nil
+}
+
+// CustomizeDiff rejects unsupported column schema changes at plan time.
+func CustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	if !d.HasChange("column") && len(d.GetChangedKeysPrefix("column")) == 0 {
+		return nil
+	}
+	o, n := d.GetChange("column")
+	if o == nil || n == nil {
+		return nil
+	}
+	_, err := checkColumnDiff(expandColumns(n), expandColumns(o))
+	return err
 }
 
 func compareIndexes(ridx *Index, didx options.IndexDescription) bool {

--- a/internal/resources/table/table_diff_test.go
+++ b/internal/resources/table/table_diff_test.go
@@ -33,6 +33,16 @@ func TestCheckColumnDiff(t *testing.T) {
 			},
 		},
 		{
+			testName: "changing column type",
+			rcolumns: []*Column{
+				{Name: "a", Type: "uint64"},
+			},
+			dcolumns: []*Column{
+				{Name: "a", Type: "uint32"},
+			},
+			expectedError: true,
+		},
+		{
 			testName: "resource with deleting columns",
 			rcolumns: []*Column{
 				{
@@ -63,6 +73,9 @@ func TestCheckColumnDiff(t *testing.T) {
 			got, err := checkColumnDiff(v.rcolumns, v.dcolumns)
 			if v.expectedError {
 				assert.Error(t, err)
+				if v.testName == "changing column type" {
+					assert.Contains(t, err.Error(), `from "uint32" to "uint64"`)
+				}
 			} else {
 				assert.NoError(t, err)
 			}

--- a/internal/resources/table/util_test.go
+++ b/internal/resources/table/util_test.go
@@ -4,8 +4,23 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestExpandColumns(t *testing.T) {
+	set := schema.NewSet(func(v interface{}) int {
+		m := v.(map[string]interface{})
+		return schema.HashString(m["name"].(string))
+	}, []interface{}{
+		map[string]interface{}{"name": "a", "type": "Uint32", "not_null": false},
+	})
+	cols := expandColumns(set)
+	require.Len(t, cols, 1)
+	assert.Equal(t, "a", cols[0].Name)
+	assert.Equal(t, "Uint32", cols[0].Type)
+}
 
 func TestTTLToISO8601(t *testing.T) {
 	const (

--- a/internal/terraform/table.go
+++ b/internal/terraform/table.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	resourcetable "github.com/ydb-platform/terraform-provider-ydb/internal/resources/table"
 	"github.com/ydb-platform/terraform-provider-ydb/sdk/terraform/auth"
 	"github.com/ydb-platform/terraform-provider-ydb/sdk/terraform/table"
 )
@@ -18,6 +19,7 @@ func ydbTableResource() *schema.Resource {
 		ReadContext:   resourceYDBTableRead,
 		UpdateContext: resourceYDBTableUpdate,
 		DeleteContext: resourceYDBTableDelete,
+		CustomizeDiff: resourcetable.CustomizeDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/internal/terraform/ydb_table_column_acc_test.go
+++ b/internal/terraform/ydb_table_column_acc_test.go
@@ -1,0 +1,136 @@
+package terraform_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccYdbTable_columnTypeChangePlanError verifies that changing a column type fails at plan time.
+func TestAccYdbTable_columnTypeChangePlanError(t *testing.T) {
+	conn := os.Getenv(envAccYDBConnection)
+	suffix := accRandomHex8(t)
+	tblPath := "tf_acc_col_type/tbl_" + suffix
+
+	configInitial := accTestConfigPrefix(conn) + fmt.Sprintf(`
+resource "ydb_table" "test" {
+  connection_string = var.connection_string
+  path              = %q
+
+  column {
+    name = "pk"
+    type = "Utf8"
+  }
+  column {
+    name = "val"
+    type = "Uint32"
+  }
+
+  primary_key = ["pk"]
+}
+`, tblPath)
+
+	configTypeChanged := accTestConfigPrefix(conn) + fmt.Sprintf(`
+resource "ydb_table" "test" {
+  connection_string = var.connection_string
+  path              = %q
+
+  column {
+    name = "pk"
+    type = "Utf8"
+  }
+  column {
+    name = "val"
+    type = "Uint64"
+  }
+
+  primary_key = ["pk"]
+}
+`, tblPath)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { accPreCheckYDB(t) },
+		ProviderFactories: accProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: configInitial,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ydb_table.test", "path", tblPath),
+					resource.TestCheckResourceAttrSet("ydb_table.test", "id"),
+					resource.TestCheckTypeSetElemNestedAttrs("ydb_table.test", "column.*", map[string]string{
+						"name": "val",
+						"type": "Uint32",
+					}),
+				),
+			},
+			{
+				Config:      configTypeChanged,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`changing column "val" type from "Uint32" to "Uint64" is not supported`),
+			},
+		},
+	})
+}
+
+// TestAccYdbTable_columnOrderNoDrift verifies that column block order in HCL does not cause plan drift.
+func TestAccYdbTable_columnOrderNoDrift(t *testing.T) {
+	conn := os.Getenv(envAccYDBConnection)
+	suffix := accRandomHex8(t)
+	tblPath := "tf_acc_col_order/tbl_" + suffix
+
+	configPKFirst := accTestConfigPrefix(conn) + fmt.Sprintf(`
+resource "ydb_table" "test" {
+  connection_string = var.connection_string
+  path              = %q
+
+  column {
+    name = "pk"
+    type = "Utf8"
+  }
+  column {
+    name = "val"
+    type = "Uint32"
+  }
+
+  primary_key = ["pk"]
+}
+`, tblPath)
+
+	configValFirst := accTestConfigPrefix(conn) + fmt.Sprintf(`
+resource "ydb_table" "test" {
+  connection_string = var.connection_string
+  path              = %q
+
+  column {
+    name = "val"
+    type = "Uint32"
+  }
+  column {
+    name = "pk"
+    type = "Utf8"
+  }
+
+  primary_key = ["pk"]
+}
+`, tblPath)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { accPreCheckYDB(t) },
+		ProviderFactories: accProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: configPKFirst,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ydb_table.test", "path", tblPath),
+				),
+			},
+			{
+				Config:   configValFirst,
+				PlanOnly: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary
- Fail `terraform plan` when an existing `ydb_table` column type is changed, because YDB only supports `ADD COLUMN` / `DROP COLUMN`, not in-place type changes.
- Extend `checkColumnDiff` to compare column types for existing columns and wire validation via `CustomizeDiff`.
- Add acceptance test for plan-time error and a unit test for `checkColumnDiff` type-change detection.

## Test plan
- [x] `go test ./internal/resources/table/...`
- [x] `go test ./internal/terraform/...`
- [ ] `TF_ACC=1 go test ./internal/terraform/ -run TestAccYdbTable_columnTypeChangePlanError -timeout 30m`


Made with [Cursor](https://cursor.com)