### PR TITLE
Expose ydb_table CustomizeDiff in the public SDK package

### DIFF
--- a/internal/resources/table/column_diff.go
+++ b/internal/resources/table/column_diff.go
@@ -1,0 +1,18 @@
+package table
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ValidateResourceDiffColumns rejects unsupported column schema changes at plan time.
+func ValidateResourceDiffColumns(d *schema.ResourceDiff) error {
+	if !d.HasChange("column") && len(d.GetChangedKeysPrefix("column")) == 0 {
+		return nil
+	}
+	o, n := d.GetChange("column")
+	if o == nil || n == nil {
+		return nil
+	}
+	_, err := checkColumnDiff(expandColumns(n), expandColumns(o))
+	return err
+}

--- a/internal/resources/table/table_diff.go
+++ b/internal/resources/table/table_diff.go
@@ -1,7 +1,6 @@
 package table
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -67,19 +66,6 @@ func checkColumnDiff(rcolumns []*Column, dcolumns []*Column) ([]*Column, error) 
 		return nil, fmt.Errorf("it is prohibited to delete columns with terraform. Columns for deletion: [%s]", strings.Join(deletedColumns, ","))
 	}
 	return columnsToAdd, nil
-}
-
-// CustomizeDiff rejects unsupported column schema changes at plan time.
-func CustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
-	if !d.HasChange("column") && len(d.GetChangedKeysPrefix("column")) == 0 {
-		return nil
-	}
-	o, n := d.GetChange("column")
-	if o == nil || n == nil {
-		return nil
-	}
-	_, err := checkColumnDiff(expandColumns(n), expandColumns(o))
-	return err
 }
 
 func compareIndexes(ridx *Index, didx options.IndexDescription) bool {

--- a/internal/terraform/table.go
+++ b/internal/terraform/table.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	resourcetable "github.com/ydb-platform/terraform-provider-ydb/internal/resources/table"
 	"github.com/ydb-platform/terraform-provider-ydb/sdk/terraform/auth"
 	"github.com/ydb-platform/terraform-provider-ydb/sdk/terraform/table"
 )
@@ -19,7 +18,7 @@ func ydbTableResource() *schema.Resource {
 		ReadContext:   resourceYDBTableRead,
 		UpdateContext: resourceYDBTableUpdate,
 		DeleteContext: resourceYDBTableDelete,
-		CustomizeDiff: resourcetable.CustomizeDiff,
+		CustomizeDiff: table.CustomizeDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/sdk/terraform/table/diff.go
+++ b/sdk/terraform/table/diff.go
@@ -1,0 +1,14 @@
+package table
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/ydb-platform/terraform-provider-ydb/internal/resources/table"
+)
+
+// CustomizeDiff rejects unsupported column schema changes at plan time.
+func CustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	return table.ValidateResourceDiffColumns(d)
+}


### PR DESCRIPTION
## Summary
- Move `CustomizeDiff` for `ydb_table` from `internal/resources/table` to the public `sdk/terraform/table` package.
- Extract column diff validation into `ValidateResourceDiffColumns` in internal, following the same pattern as external data source auth validation.
- Wire the provider resource to use `table.CustomizeDiff` from the SDK.

## Test plan
- [x] `go build ./...`
- [ ] `terraform plan` on an existing `ydb_table` with unchanged columns (no diff errors)
- [ ] `terraform plan` when changing a column type (plan-time error as before)


Made with [Cursor](https://cursor.com)